### PR TITLE
Add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitignore export-ignore
+.gitattributes export-ignore


### PR DESCRIPTION
The latest release tarball of mwrap (v0.33.12) contains the .gitignore file.  The presence of this file makes the maintenance of the Debian package harder, because of merging issues with the local .gitnore file. At any rate, it is not usual to distribute the .gitignore file in release tarballs, since it is only useful for developers interacting with the VCS repository.

In this commit, the .gitattributes file is added, which instructs the GitHub's release mechanism on how to prevent the inclusion of the .gitignore file into the release tarball.