### PR TITLE
Do not hardcode the CC and CXX variables

### DIFF
--- a/make.inc
+++ b/make.inc
@@ -10,8 +10,8 @@ OOFLAG=-DR2008OO
 # Uncomment this line for C99 complex support
 TESTC99COMPLEX=test_c99_complex
 
-CC=    gcc
-CXX=   g++
+CC := $(if $(CC),$(CC),gcc)
+CXX := $(if $(CXX),$(CXX),g++)
 MEX=   mex $(OOFLAG)
 
 # Use the following for 64-bit MEX

--- a/src/Makefile
+++ b/src/Makefile
@@ -37,7 +37,7 @@ mwrap-support.h: mwrap-support.c stringify
 	./stringify mex_header < mwrap-support.c > mwrap-support.h
 
 stringify: stringify.c
-	gcc -o stringify stringify.c
+	$(CC) -o stringify stringify.c
 
 
 # === Clean-up targets ===


### PR DESCRIPTION
The variables CC and CXX are hardcoded in src/Makefile.  This makes them impossible to be changed by the user, when running make from the command line. In particular, this complicates the maintenance of the package in distributions like Debian, because some tools that automate the package building needs sometimes to change the compiler suite.  This commit fixes the problem by using the $(if) construct in src/Makefile.

Also, the rule for building the stringify executable uses now $(CC) instead of directly gcc.