### PR TITLE
Avoid compilation warning

### DIFF
--- a/src/mwrap.y
+++ b/src/mwrap.y
@@ -243,6 +243,7 @@ int yyerror(const char* s)
 {
     fprintf(stderr, "Parse error (%s:%d): %s\n", current_ifname.c_str(),
             linenum, s);
+    return 0;
 }
 
 char* mwrap_strdup(const char* s)


### PR DESCRIPTION
This commit avoids this compilation warning (with gcc version 10.1.0):

```
mwrap.y: In function ‘int yyerror(const char*)’:
mwrap.y:248:1: warning: no return statement in function returning non-void [-Wreturn-type]
  248 | }
      | ^
```