### PR TITLE
Unit testing failure with Bison 3.6.3

### DIFF
--- a/testing/test_syntax.ref
+++ b/testing/test_syntax.ref
@@ -1,2 +1,2 @@
 Parse error (test_syntax.mw:4): syntax error, unexpected NON_C_LINE, expecting ';'
-Parse error (test_syntax.mw:8): syntax error, unexpected $end, expecting ';'
+Parse error (test_syntax.mw:8): syntax error, unexpected end of file, expecting ';'


### PR DESCRIPTION
Running the unit testing of mwrap fails against Bison 3.6.3, with the following error message:

```
(cd testing; make)
[…]
mkoctfile --mex test_c99_complexmex.c
../mwrap -cppcomplex test_syntax.mw 2> test_syntax.log
make[1]: [Makefile:33: test_syntax] Error 1 (ignored)
diff test_syntax.log test_syntax.ref
2c2
< Parse error (test_syntax.mw:8): syntax error, unexpected end of file, expecting ';'
---
> Parse error (test_syntax.mw:8): syntax error, unexpected $end, expecting ';'
```

This commit fixes the problem.