### PR TITLE
Explicitly return int value

### DIFF
--- a/testing/test_fortran1.mw
+++ b/testing/test_fortran1.mw
@@ -6,6 +6,7 @@ $ #endif
 $ int foo_(int* a, int* b, int* c)
 $ {
 $     *a = *b + *c;
+$     return(0);
 $ }
 
 # FORTRAN foo(output int* a, int 1, int 2);


### PR DESCRIPTION
In the unit test testing/test_fortran1.mw, the C function to be wrapped does not return an `int` value, as it should do.  This causes the following warning when compiling mwrap against GCC 10 with -Wreturn-type in a Debian system:

```
mkoctfile --mex test_fortran1mex.cc
test_fortran1mex.cc: In function ‘int foo_(int*, int*, int*)’:
test_fortran1mex.cc:968:2: warning: no return statement in function returning non-void [-Wreturn-type]
  968 |  }
      |  ^
```

This was causing segmentation faults on several architectures ([armhf](https://buildd.debian.org/status/fetch.php?pkg=mwrap&arch=armhf&ver=1.0-1&stamp=1596905640&raw=0), [i386](https://buildd.debian.org/status/fetch.php?pkg=mwrap&arch=i386&ver=1.0-1&stamp=1596906267&raw=0), [mips64el](https://buildd.debian.org/status/fetch.php?pkg=mwrap&arch=mips64el&ver=1.0-1&stamp=1596905576&raw=0), [mipsel](https://buildd.debian.org/status/fetch.php?pkg=mwrap&arch=mipsel&ver=1.0-1&stamp=1596905480&raw=0), and  [ppc64el](https://buildd.debian.org/status/fetch.php?pkg=mwrap&arch=ppc64el&ver=1.0-1&stamp=1596913952&raw=0)).

With a version of the Debian package that includes the changes in the present commit, [everything seems fine](https://buildd.debian.org/status/package.php?p=mwrap).