### PR TITLE
adding underscore0 option for windows libmwblas mingw support

### DIFF
--- a/doc/mwrap.tex
+++ b/doc/mwrap.tex
@@ -761,10 +761,13 @@ can be passed to the {\tt mex} script to change this behavior:
 \begin{itemize}
 \item
   {\tt -DMWF77\_CAPS} -- Assume the FORTRAN compiler uses all-caps
-  names and no extra underscores.  Used by Compaq FORTRAN (I think).
+  names and no extra underscores.  Used by Compaq FORTRAN, and intel fortran compiler on windows (I think).
 \item
   {\tt -DMWF77\_UNDERSCORE1} -- Append a single underscore to an
-  all-lower-case name.  Used by the Intel FORTRAN compiler.
+  all-lower-case name.  Used by the GNU FORTRAN compiler and the intel fortran compiler on UNIX systems (I think).
+\item
+  {\tt -DMWF77\_UNDERSCORE0} -- Append no underscore to an
+  all-lower-case name.  Used by the GNU fortran with the -fno-underscoring flag
 \end{itemize}
 
 It is possible to use the {\tt typedef numeric} construct to introduce

--- a/src/mwrap-cgen.cc
+++ b/src/mwrap-cgen.cc
@@ -281,6 +281,28 @@ void mex_define_underscore1_fnames(FILE* fp, Func* f)
 }
 
 
+void mex_define_underscore0_fname(FILE* fp, Func* f)
+{
+    fprintf(fp, "#define MWF77_%s ", f->funcv);
+    for (char* s = f->funcv; *s; ++s)
+        fputc(tolower(*s), fp);
+    fprintf(fp, "\n");
+}
+
+
+void mex_define_underscore0_fnames(FILE* fp, Func* f)
+{
+    set<string> fnames;
+    for (; f; f = f->next) {
+        if (f->fort && fnames.find(f->funcv) == fnames.end()) {
+            mex_define_underscore0_fname(fp, f);
+            fnames.insert(f->funcv);
+        }
+    }
+}
+
+
+
 void mex_define_f2c_fname(FILE* fp, Func* f)
 {
     fprintf(fp, "#define MWF77_%s ", f->funcv);
@@ -314,6 +336,8 @@ void mex_define_fnames(FILE* fp, Func* f)
     mex_define_caps_fnames(fp, f);
     fprintf(fp, "#elif defined(MWF77_UNDERSCORE1)\n");
     mex_define_underscore1_fnames(fp, f);
+    fprintf(fp, "#elif defined(MWF77_UNDERSCORE0)\n");
+    mex_define_underscore0_fnames(fp, f);
     fprintf(fp, "#else /* f2c convention */\n");
     mex_define_f2c_fnames(fp, f);
     fprintf(fp, "#endif\n\n");


### PR DESCRIPTION
Added an option for underscore0, tested it on the FMM3D library on Mac and windows