### PR TITLE
Avoid race condition in parallel make

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,10 +12,10 @@ include ../make.inc
 mwrap.o: mwrap.cc lex.yy.c mwrap-ast.h
 	$(CXX) -c mwrap.cc
 
-mwrap.cc: mwrap.y
+mwrap.cc mwrap.hh: mwrap.y
 	$(BISON) -d -v mwrap.y -o mwrap.cc
 
-lex.yy.o: lex.yy.c
+lex.yy.o: lex.yy.c mwrap.hh
 	$(CC) -c lex.yy.c
 
 lex.yy.c: mwrap.l


### PR DESCRIPTION
When running the make command with the -j option, race conditions may happen, as the one met in one of the automatic build of the Debian package mwrap:
http://qa-logs.debian.net/2025/01/06/mwrap_1.1.1-3_unstable.log

The relevant parts ot the log file above are:

```
	make -j8 "INSTALL=install --strip-program=true"
    […]
    flex mwrap.l
    […]
    cc -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wdate-time -D_FORTIFY_SOURCE=2  -c -o lex.yy.o lex.yy.c
    mwrap.l:10:10: fatal error: mwrap.hh: No such file or directory
       10 | #include "mwrap.hh"
          |          ^~~~~~~~~~
```

This problem can also be explicitly triggered by doing this:

```
    $ cd src/
    $ make realclean
    rm -f mwrap.output
    rm -f *.o *~
    rm -f stringify
    rm -f lex.yy.c mwrap.cc mwrap.hh mwrap-support.h mwrap.pdf
    $ make lex.yy.o
    flex mwrap.l
    cc -c lex.yy.c
    mwrap.l:10:10: fatal error: mwrap.hh: No such file or directory
       10 | #include "mwrap.hh"
          |          ^~~~~~~~~~
    compilation terminated.
    make: *** [Makefile:19: lex.yy.o] Error 1
```

The problem here is that mwrap.l contains this line:

```
    #include "mwrap.hh"
```
This line is propagated into lex.yy.c via the flex command. However, the mwrap.hh file is generated y the bison command, but no explicit dependency between lex.yy.o and mwrap.l is delcared in the Makefile.

Hence, when using the -j option of the make command (after running "make realclean", which is the case of the ebian package), then a race condition may happen, since nothing prevents the commands "flex nwrap.l; cc -c lex.yy.c" of happenning before the "bison mwrap.y -o mwrap.cc" command.