### PR TITLE
Avoid deprecated Bison directive

### DIFF
--- a/src/mwrap.y
+++ b/src/mwrap.y
@@ -106,7 +106,7 @@ inline void add_func(Func* func)
 %type <expr> arrayspec exprs exprrest expr
 %type <inherits> inheritslist inheritsrest
 
-%error-verbose
+%define parse.error verbose
 
 %%
 statements: statement statements | ;


### PR DESCRIPTION
The directive `%error-verbose` is deprecated since Bison 3.0 (and [advertised as such](https://lists.gnu.org/archive/html/info-gnu/2019-01/msg00016.html) since Bison 3.3). Use `%define parse.error verbose` instead.