### PR TITLE
Cope with error verbose directive in both versions 2 and 3 of Bison

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,6 +15,15 @@ mwrap.o: mwrap.cc lex.yy.c mwrap-ast.h
 mwrap.cc mwrap.hh: mwrap.y
 	$(BISON) -d -v mwrap.y -o mwrap.cc
 
+ifeq ($(shell bison --version 2>&1 | sed -n 's/^.*GNU Bison.* \([0-9]*\).*$$/\1/p'), 3)
+ERROR_VERBOSE = %define parse.error verbose
+else
+ERROR_VERBOSE = %error-verbose
+endif
+
+mwrap.y: mwrap.y.in
+	sed -e 's/@ERROR_VERBOSE@/$(ERROR_VERBOSE)/' < mwrap.y.in > mwrap.y
+
 lex.yy.o: lex.yy.c mwrap.hh
 	$(CC) -c lex.yy.c
 
@@ -48,5 +57,5 @@ clean:
 	rm -f stringify
 
 realclean: clean
-	rm -f lex.yy.c mwrap.cc mwrap.hh mwrap-support.h mwrap.pdf
+	rm -f mwrap.y lex.yy.c mwrap.cc mwrap.hh mwrap-support.h mwrap.pdf
 

--- a/src/mwrap.y.in
+++ b/src/mwrap.y.in
@@ -106,15 +106,7 @@ inline void add_func(Func* func)
 %type <expr> arrayspec exprs exprrest expr
 %type <inherits> inheritslist inheritsrest
 
-%error-verbose
-/* Avoid deprecated Bison directive
-The directive %error-verbose is deprecated since Bison 3.0 (and
-advertised as such since Bison 3.3). Use "%define parse.error verbose"
-instead. MacOS Xcode, Mar 10, 2025, bison --version, bison (GNU Bison) 2.3
-*/
-/*
-%define parse.error verbose
-*/
+@ERROR_VERBOSE@
 
 %%
 statements: statement statements | ;


### PR DESCRIPTION
This is a follow-up to PR #14.

In the present PR, the file src/mwrap.y is transformed into src/mwrap.y.in, which now contains an @ERROR_VERBOSE@ tag which is replaced by the Makefile to generate the final src/mwrap.y.

I ensured that this change works correctly against both versions 2 and 3 of Bison.

N.B.: I hesitated to put the `ifeq` logic file in the `make.inc`, but I think that `src/Makefile` is a good place for it.
