### PR TITLE
Drop mwrap.pdf from the list of files to be cleaned

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -57,5 +57,4 @@ clean:
 	rm -f stringify
 
 realclean: clean
-	rm -f mwrap.y lex.yy.c mwrap.cc mwrap.hh mwrap-support.h mwrap.pdf
-
+	rm -f mwrap.y lex.yy.c mwrap.cc mwrap.hh mwrap-support.h


### PR DESCRIPTION
The `mwrap.pdf` is not built in the `src/` directory, but in the `doc/` directory. Removing it from the `clean` target.