### PR TITLE
Ensure reproducible result when building the documentation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,12 @@
 all: mwrap.pdf
 
+RELEASE_DATE = $(shell grep "^Version " ../NEWS | head -n1 | sed "s/^Version .*(\(.*\)):/\1/")
+
+mwrap.tex: mwrap.tex.in
+	sed "s/@RELEASE_DATE@/$(RELEASE_DATE)/" < mwrap.tex.in > mwrap.tex
+
 mwrap.pdf: mwrap.tex
 	pdflatex mwrap.tex
 
 clean:
-	rm -f mwrap.aux mwrap.log mwrap.pdf
+	rm -f mwrap.aux mwrap.log mwrap.tex mwrap.pdf

--- a/doc/mwrap.tex.in
+++ b/doc/mwrap.tex.in
@@ -14,6 +14,7 @@
 
 \title{\mwrap\ User Guide\\ Version 1.3}
 \author{D.~Bindel, A.~Barnett, Z.~Gimbutas, M.~Rachh, L.~Lu, R.~Laboissi\`ere}
+\date{@RELEASE_DATE@}
 
 \pagestyle{fancy}
 


### PR DESCRIPTION
If there is no `\date{}` statement in a LaTeX file, the date of compilation is inserted into the document header. This results in non-reproducible builds of the PDF file, which is particularly problematic when generating the Debian package for mwrap.

With this commit, the `src/mwrap.tex` file is generated from the new `src/mwrap.tex.in` file, which contains the `\date{}` statement with a placeholder as argument. In the `doc/Makefile` file, the placeholder is substituted by the date of the latest release, obtained from the `NEWS` file.